### PR TITLE
LPS-112984 Update lastModified when a new JSBundle is deployed or an existing one is redeployed

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-web/build.gradle
@@ -71,6 +71,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/JavaScriptPortalWebResourcesCleaner.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/JavaScriptPortalWebResourcesCleaner.java
@@ -14,12 +14,16 @@
 
 package com.liferay.frontend.js.web.internal;
 
+import com.liferay.frontend.js.loader.modules.extender.npm.JSBundle;
+
+import java.util.Map;
 import java.util.ResourceBundle;
 
 import javax.servlet.ServletContext;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceListener;
 import org.osgi.framework.ServiceReference;
@@ -27,6 +31,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.util.tracker.BundleTracker;
+import org.osgi.util.tracker.BundleTrackerCustomizer;
 
 /**
  * @author Shuyang Zhou
@@ -52,12 +58,22 @@ public class JavaScriptPortalWebResourcesCleaner {
 			_serviceListener,
 			"(&(!(javax.portlet.name=*))(language.id=*)(objectClass=" +
 				ResourceBundle.class.getName() + "))");
+
+		_bundleTracker = new BundleTracker<>(
+			bundleContext, Bundle.ACTIVE,
+			new JavaScriptPortalWebResourcesBundleTrackerCustomizer());
+
+		_bundleTracker.open();
 	}
 
 	@Deactivate
 	protected void deactivate(BundleContext bundleContext) {
 		bundleContext.removeServiceListener(_serviceListener);
+
+		_bundleTracker.close();
 	}
+
+	private BundleTracker<JSBundle> _bundleTracker;
 
 	@Reference
 	private JavaScriptPortalWebResources _javaScriptPortalWebResources;
@@ -68,5 +84,30 @@ public class JavaScriptPortalWebResourcesCleaner {
 		target = "(&(original.bean=true)(bean.id=javax.servlet.ServletContext))"
 	)
 	private ServletContext _servletContext;
+
+	private class JavaScriptPortalWebResourcesBundleTrackerCustomizer
+		implements BundleTrackerCustomizer<JSBundle> {
+
+		@Override
+		public JSBundle addingBundle(Bundle bundle, BundleEvent bundleEvent) {
+			_javaScriptPortalWebResources.updateLastModifed(
+				bundle.getLastModified());
+
+			Map<Bundle, JSBundle> tracked = _bundleTracker.getTracked();
+
+			return tracked.get(bundle);
+		}
+
+		@Override
+		public void modifiedBundle(
+			Bundle bundle, BundleEvent bundleEvent, JSBundle jsBundle) {
+		}
+
+		@Override
+		public void removedBundle(
+			Bundle bundle, BundleEvent bundleEvent, JSBundle jsBundle) {
+		}
+
+	}
 
 }


### PR DESCRIPTION
Hi @marianoalvarosaiz, 

The goal is to update the `lastModified` date whenever a module with js is deployed, so that a simple page reload will include the changes (because the `getComboPath` has the updated timestamp value for the parameter `t`). 

This approach uses a `BundleTrackerCustomizer` for `JSBundle`. The implemented methods are quite minimal. I was inspired by the one in `NPMRegistryImpl`.