### PR TITLE
LPS-123020 Tests

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -17,11 +17,14 @@ package com.liferay.oauth2.provider.client.test;
 import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandler;
 import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandlerFactory;
 import com.liferay.oauth2.provider.scope.spi.scope.finder.ScopeFinder;
 import com.liferay.oauth2.provider.scope.spi.scope.mapper.ScopeMapper;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -45,6 +48,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.List;
@@ -111,6 +115,57 @@ public abstract class BaseTestPreparatorBundleActivator
 			() -> UserLocalServiceUtil.deleteUser(user.getUserId()));
 
 		return user;
+	}
+
+	protected OAuth2Authorization addOAuth2Authorization(
+		long companyId, User user, OAuth2Application oAuth2Application,
+		String accessTokenContent, Date accessTokenCreateDate,
+		Date accessTokenExpirationDate) {
+
+		return addOAuth2Authorization(
+			companyId, user, oAuth2Application, accessTokenContent,
+			accessTokenCreateDate, accessTokenExpirationDate, null, null, null);
+	}
+
+	protected OAuth2Authorization addOAuth2Authorization(
+		long companyId, User user, OAuth2Application oAuth2Application,
+		String accessTokenContent, Date accessTokenCreateDate,
+		Date accessTokenExpirationDate, String refreshTokenContent,
+		Date refreshTokenCreateDate, Date refreshTokenExpirationDate) {
+
+		ServiceReference<OAuth2AuthorizationLocalService> serviceReference =
+			bundleContext.getServiceReference(
+				OAuth2AuthorizationLocalService.class);
+
+		OAuth2AuthorizationLocalService oAuth2AuthorizationLocalService =
+			bundleContext.getService(serviceReference);
+
+		autoCloseables.add(() -> bundleContext.ungetService(serviceReference));
+
+		OAuth2Authorization oAuth2Authorization =
+			oAuth2AuthorizationLocalService.addOAuth2Authorization(
+				companyId, user.getUserId(), user.getFullName(),
+				oAuth2Application.getOAuth2ApplicationId(),
+				oAuth2Application.getOAuth2ApplicationScopeAliasesId(),
+				accessTokenContent, accessTokenCreateDate,
+				accessTokenExpirationDate, "localhost", "127.0.0.1",
+				refreshTokenContent, refreshTokenCreateDate,
+				refreshTokenExpirationDate);
+
+		autoCloseables.add(
+			() -> {
+				OAuth2Authorization fetchedAuth2Authorization =
+					OAuth2AuthorizationLocalServiceUtil.
+						fetchOAuth2Authorization(
+							oAuth2Authorization.getOAuth2AuthorizationId());
+
+				if (fetchedAuth2Authorization != null) {
+					OAuth2AuthorizationLocalServiceUtil.
+						deleteOAuth2Authorization(fetchedAuth2Authorization);
+				}
+			});
+
+		return oAuth2Authorization;
 	}
 
 	protected User addUser(Company company) throws Exception {

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ExpiredAuthorizationsAfterlifeTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ExpiredAuthorizationsAfterlifeTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.client.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleActivator;
+
+/**
+ * @author Jose L. Bango
+ */
+@RunWith(Arquillian.class)
+public class ExpiredAuthorizationsAfterlifeTest extends BaseClientTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void test() throws Exception {
+		_oAuth2AuthorizationLocalService.deleteExpiredOAuth2Authorizations();
+
+		OAuth2Authorization oAuth2Authorization1 =
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("accessToken1");
+
+		Assert.assertNull(oAuth2Authorization1);
+
+		OAuth2Authorization oAuth2Authorization2 =
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("accessToken2");
+
+		Assert.assertNotNull(oAuth2Authorization2);
+
+		OAuth2Authorization oAuth2Authorization3 =
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("accessToken3");
+
+		Assert.assertNotNull(oAuth2Authorization3);
+	}
+
+	public static class ExpiredAuthorizationsTestPreparatorBundleActivator
+		extends BaseTestPreparatorBundleActivator {
+
+		@Override
+		protected void prepareTest() throws Exception {
+			updateOAuth2ProviderConfiguration(
+				MapUtil.singletonDictionary(
+					"oauth2.expired.authorizations.afterlife.duration", 86400));
+
+			long defaultCompanyId = PortalUtil.getDefaultCompanyId();
+
+			User user = UserTestUtil.getAdminUser(defaultCompanyId);
+
+			OAuth2Application oAuth2Application = createOAuth2Application(
+				defaultCompanyId, user, "oauthTestApplication",
+				Arrays.asList("everything.read"));
+
+			Map<String, Date> accessTokenMap = HashMapBuilder.<String, Date>put(
+				"accessToken1",
+				new Date(System.currentTimeMillis() - (Time.DAY * 2))
+			).put(
+				"accessToken2",
+				new Date(System.currentTimeMillis() - (Time.HOUR * 2))
+			).put(
+				"accessToken3",
+				new Date(System.currentTimeMillis() + (Time.HOUR * 2))
+			).build();
+
+			accessTokenMap.forEach(
+				(accessTokenContent, accessTokenExpirationDate) ->
+					addOAuth2Authorization(
+						defaultCompanyId, user, oAuth2Application,
+						accessTokenContent, new Date(),
+						accessTokenExpirationDate));
+		}
+
+	}
+
+	@Override
+	protected BundleActivator getBundleActivator() {
+		return new ExpiredAuthorizationsAfterlifeTest.
+			ExpiredAuthorizationsTestPreparatorBundleActivator();
+	}
+
+	@Inject
+	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
+
+}


### PR DESCRIPTION
Update test preparator and add new class to check that only the correct authorizations are deleted, taking into account the configured afterlife duration

---

Hola Mariano, te paso la pull que te decía.

- El ticket Jira es este: https://issues.liferay.com/browse/LPS-123020
- Pull a master: https://github.com/liferay-appsec/liferay-portal/pull/637

No tiene misterio pero por resumir, básicamente en el Preparator añado métodos para crear las autorizaciones, y creé una clase para testear el borrado de autorizaciones según su Afterlife:

- Una autorización a borrar, expirada hace 2 días
- Una autorización a mantener, expirada solo hace 2 horas
- Una autorización a mantener, aún no expirada

Ya me dices, gracias!
