### PR TITLE
LPD-23983 Execute the schema migration in one step

### DIFF
--- a/modules/apps/portal/portal-db-schema-definition/src/main/java/com/liferay/portal/db/schema/definition/internal/exporter/DBSchemaDefinitionExporter.java
+++ b/modules/apps/portal/portal-db-schema-definition/src/main/java/com/liferay/portal/db/schema/definition/internal/exporter/DBSchemaDefinitionExporter.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.model.ReleaseConstants;
+import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.patcher.PatcherValues;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
@@ -301,8 +302,8 @@ public class DBSchemaDefinitionExporter {
 	@Reference
 	private ConfigurationAdmin _configurationAdmin;
 
-	@Reference
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+	@Reference(target = "(module.service.lifecycle=db.schema.export2)")
+	private ModuleServiceLifecycle _moduleServiceLifecycle;
 
 	@Reference
 	private ReleaseLocalService _releaseLocalService;

--- a/modules/apps/portal/portal-db-schema-definition/src/main/java/com/liferay/portal/db/schema/definition/internal/exporter/DBSchemaDefinitionExporter.java
+++ b/modules/apps/portal/portal-db-schema-definition/src/main/java/com/liferay/portal/db/schema/definition/internal/exporter/DBSchemaDefinitionExporter.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.db.schema.definition.internal.exporter;
 
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
@@ -299,6 +300,9 @@ public class DBSchemaDefinitionExporter {
 
 	@Reference
 	private ConfigurationAdmin _configurationAdmin;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
 	private ReleaseLocalService _releaseLocalService;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleasePublisher.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleasePublisher.java
@@ -121,7 +121,7 @@ public class ReleasePublisher {
 
 	private BundleContext _bundleContext;
 
-	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED)
+	@Reference(target = "(|" + ModuleServiceLifecycle.PORTAL_INITIALIZED + "(module.service.lifecycle=db.schema.export))")
 	private ModuleServiceLifecycle _moduleServiceLifecycle;
 
 	@Reference

--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/DBUpgradeClient.java
@@ -236,7 +236,7 @@ public class DBUpgradeClient {
 					upgradeFailed = true;
 				}
 
-				if (line.equals("Exiting DBUpgrader#main(String[]).")) {
+				if (line.equals("Exiting migration")) {
 					break;
 				}
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -157,7 +157,9 @@ public class DBUpgrader {
 
 			InitUtil.registerContext();
 
-			_registerModuleServiceLifecycle("portal.initialized");
+			_registerModuleServiceLifecycle("db.schema.export");
+
+			_registerModuleServiceLifecycle("db.schema.export2");
 		}
 		catch (Exception exception) {
 			_log.error(exception);

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -147,13 +147,7 @@ public class DBUpgrader {
 	}
 
 	public static void main(String[] args) {
-		String result = "Completed";
-
-		_upgradeClient = true;
-
 		try {
-			_initUpgradeStopwatch();
-
 			PortalClassPathUtil.initializeClassPaths(null);
 
 			InitUtil.initWithSpring(
@@ -161,38 +155,15 @@ public class DBUpgrader {
 					PropsUtil.getArray(PropsKeys.SPRING_CONFIGS)),
 				true, false, () -> StartupHelperUtil.setUpgrading(true));
 
-			StartupHelperUtil.printPatchLevel();
-
-			upgradePortal();
-
 			InitUtil.registerContext();
 
-			upgradeModules();
-
-			BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-
-			Collection<?> collection = bundleContext.getServiceReferences(
-				Store.class, "(default=true)");
-
-			if (collection.isEmpty()) {
-				throw new IllegalStateException("Missing default Store");
-			}
+			_registerModuleServiceLifecycle("portal.initialized");
 		}
 		catch (Exception exception) {
 			_log.error(exception);
-
-			result = "Failed";
-		}
-		finally {
-			StartupHelperUtil.setUpgrading(false);
-
-			System.out.println(
-				StringBundler.concat(
-					"\n", result, " Liferay upgrade process in ",
-					_stopWatch.getTime() / Time.SECOND, " seconds"));
 		}
 
-		System.out.println("Exiting DBUpgrader#main(String[]).");
+		System.out.println("Exiting migration");
 	}
 
 	public static void startUpgradeLogAppender() {


### PR DESCRIPTION
Hi @marianoalvarosaiz,

These are the minimum changes to make the migration work in one step. We additionally have to add a file com.liferay.portal.db.schema.definition.internal.configuration.DBSchemaDefinitionExporterConfiguration.config before starting the tool or call the db-schema-definition-exporter somehow.

Let me know what you think.
