### PR TITLE
PTR-8653 Restrict DDM template selector scope to prevent cross-site leakage

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-api/src/main/java/com/liferay/dynamic/data/mapping/item/selector/DDMTemplateItemSelectorCriterion.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-api/src/main/java/com/liferay/dynamic/data/mapping/item/selector/DDMTemplateItemSelectorCriterion.java
@@ -21,6 +21,10 @@ public class DDMTemplateItemSelectorCriterion
 		return _ddmStructureId;
 	}
 
+	public boolean isSelectAncestorScopes() {
+		return _selectAncestorScopes;
+	}
+
 	public void setClassNameId(long classNameId) {
 		_classNameId = classNameId;
 	}
@@ -29,7 +33,12 @@ public class DDMTemplateItemSelectorCriterion
 		_ddmStructureId = ddmStructureId;
 	}
 
+	public void setSelectAncestorScopes(boolean selectAncestorScopes) {
+		_selectAncestorScopes = selectAncestorScopes;
+	}
+
 	private long _classNameId;
 	private long _ddmStructureId;
+	private boolean _selectAncestorScopes = true;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
@@ -10,6 +10,7 @@ import com.liferay.dynamic.data.mapping.item.selector.DDMTemplateItemSelectorCri
 import com.liferay.dynamic.data.mapping.item.selector.DDMTemplateItemSelectorReturnType;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateServiceUtil;
 import com.liferay.dynamic.data.mapping.util.DDMUtil;
 import com.liferay.item.selector.ItemSelectorReturnType;
@@ -20,6 +21,7 @@ import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -110,10 +112,7 @@ public class DDMTemplateItemSelectorViewDescriptor
 				getOrderByCol(), getOrderByType()));
 		ddmTemplateSearchContainer.setOrderByType(getOrderByType());
 
-		long[] groupIds =
-			SiteConnectedGroupGroupProviderUtil.
-				getCurrentAndAncestorSiteAndDepotGroupIds(
-					_themeDisplay.getScopeGroupId(), false, true);
+		long[] groupIds = _getGroupIds();
 
 		ddmTemplateSearchContainer.setResultsAndTotal(
 			() -> DDMTemplateServiceUtil.search(
@@ -144,6 +143,34 @@ public class DDMTemplateItemSelectorViewDescriptor
 	@Override
 	public boolean isShowSearch() {
 		return true;
+	}
+
+	private long[] _getGroupIds() throws PortalException {
+		if (_ddmTemplateItemSelectorCriterion.isSelectAncestorScopes()) {
+			return SiteConnectedGroupGroupProviderUtil.
+				getCurrentAndAncestorSiteAndDepotGroupIds(
+					_themeDisplay.getScopeGroupId(), false, true);
+		}
+
+		long[] groupIds = {
+			_themeDisplay.getScopeGroupId(), _themeDisplay.getCompanyGroupId()
+		};
+
+		long ddmStructureId =
+			_ddmTemplateItemSelectorCriterion.getDDMStructureId();
+
+		if (ddmStructureId > 0) {
+			DDMStructure ddmStructure =
+				DDMStructureLocalServiceUtil.fetchDDMStructure(ddmStructureId);
+
+			if ((ddmStructure != null) &&
+				!ArrayUtil.contains(groupIds, ddmStructure.getGroupId())) {
+
+				groupIds = ArrayUtil.append(groupIds, ddmStructure.getGroupId());
+			}
+		}
+
+		return groupIds;
 	}
 
 	private String _getKeywords() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
@@ -141,6 +141,11 @@ public class DDMTemplateItemSelectorViewDescriptor
 	}
 
 	@Override
+	public boolean isShowBreadcrumb() {
+		return _ddmTemplateItemSelectorCriterion.isSelectAncestorScopes();
+	}
+
+	@Override
 	public boolean isShowSearch() {
 		return true;
 	}

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -565,6 +565,8 @@ public class JournalContentDisplayContext {
 						ddmStructure.getStructureId());
 				}
 
+				ddmTemplateItemSelectorCriterion.setSelectAncestorScopes(false);
+
 				ddmTemplateItemSelectorCriterion.
 					setDesiredItemSelectorReturnTypes(
 						new DDMTemplateItemSelectorReturnType());

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -1315,6 +1315,7 @@ public class JournalEditArticleDisplayContext {
 					PortalUtil.getClassNameId(JournalArticle.class.getName()));
 				ddmTemplateItemSelectorCriterion.setDDMStructureId(
 					_ddmStructure.getStructureId());
+				ddmTemplateItemSelectorCriterion.setSelectAncestorScopes(false);
 				ddmTemplateItemSelectorCriterion.
 					setDesiredItemSelectorReturnTypes(
 						new DDMTemplateItemSelectorReturnType());


### PR DESCRIPTION
## Summary
- Fixes [PTR-8653](https://liferay.atlassian.net/browse/PTR-8653): when a DDM structure lives in an Asset Library shared across sites, the template Item Selector exposes templates from unrelated sites — selecting one causes `NoSuchTemplateException` on publish.
- Adds a `selectAncestorScopes` flag to `DDMTemplateItemSelectorCriterion` (default `true`, mirroring `DDMStructureItemSelectorCriterion`).
- When the flag is `false`, `DDMTemplateItemSelectorViewDescriptor` restricts `groupIds` to `[scopeGroupId, companyGroupId, structure.groupId]` and hides the breadcrumb that carries the "Sites and Libraries" navigation entry.
- `JournalContentDisplayContext` (Web Content Display widget) and `JournalEditArticleDisplayContext` (article editor) opt in.

## Commits
1. `PTR-8653 Add selectAncestorScopes flag to DDMTemplateItemSelectorCriterion`
2. `PTR-8653 Restrict template search scope when selectAncestorScopes is false`
3. `PTR-8653 Hide breadcrumb in DDM template selector when selectAncestorScopes is false`
4. `PTR-8653 Restrict DDM template scope in Web Content Display widget`
5. `PTR-8653 Restrict DDM template scope in Web Content article editor`

## Test plan
- [ ] Create an Asset Library; create a DDM structure in it; share with Site A and Site B; create one template per scope (Site A, Site B, Asset Library).
- [ ] From Site A → Web Content → Create Article → select the Asset-Library structure → open the template picker. Expect Site A + global + Asset Library templates. Site B templates must NOT be visible, and no breadcrumb should offer navigation to another site.
- [ ] Repeat from the Web Content Display widget configuration.
- [ ] Regression: structure owned by Site A (not an Asset Library) — template picker behavior should be unchanged for the user.
- [ ] Confirm selecting a legitimate template (from A / global / Asset Library) still publishes cleanly.

## Related
There is an alternative fix in `Ankita288/liferay-portal@master` for the same symptom (`LPP-63211`) at the InfoItem provider layer, touching different files. The two approaches are complementary; coordination may be needed before either lands upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
