### PR TITLE
LPD-87387 Fix cross-site template selection for Asset Library structures

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorView.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorView.java
@@ -7,6 +7,7 @@ package com.liferay.dynamic.data.mapping.item.selector.web.internal;
 
 import com.liferay.dynamic.data.mapping.item.selector.DDMTemplateItemSelectorCriterion;
 import com.liferay.dynamic.data.mapping.item.selector.DDMTemplateItemSelectorReturnType;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.ItemSelectorViewDescriptorRenderer;
@@ -63,13 +64,16 @@ public class DDMTemplateItemSelectorView
 			servletRequest, servletResponse, ddmTemplateItemSelectorCriterion,
 			portletURL, itemSelectedEventName, search,
 			new DDMTemplateItemSelectorViewDescriptor(
-				ddmTemplateItemSelectorCriterion,
+				_ddmStructureLocalService, ddmTemplateItemSelectorCriterion,
 				(HttpServletRequest)servletRequest, portletURL));
 	}
 
 	private static final List<ItemSelectorReturnType>
 		_supportedItemSelectorReturnTypes = Collections.singletonList(
 			new DDMTemplateItemSelectorReturnType());
+
+	@Reference
+	private DDMStructureLocalService _ddmStructureLocalService;
 
 	@Reference
 	private ItemSelectorViewDescriptorRenderer<DDMTemplateItemSelectorCriterion>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
@@ -10,6 +10,7 @@ import com.liferay.dynamic.data.mapping.item.selector.DDMTemplateItemSelectorCri
 import com.liferay.dynamic.data.mapping.item.selector.DDMTemplateItemSelectorReturnType;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateServiceUtil;
 import com.liferay.dynamic.data.mapping.util.DDMUtil;
 import com.liferay.item.selector.ItemSelectorReturnType;
@@ -39,9 +40,11 @@ public class DDMTemplateItemSelectorViewDescriptor
 	implements ItemSelectorViewDescriptor<DDMTemplate> {
 
 	public DDMTemplateItemSelectorViewDescriptor(
+		DDMStructureLocalService ddmStructureLocalService,
 		DDMTemplateItemSelectorCriterion ddmTemplateItemSelectorCriterion,
 		HttpServletRequest httpServletRequest, PortletURL portletURL) {
 
+		_ddmStructureLocalService = ddmStructureLocalService;
 		_ddmTemplateItemSelectorCriterion = ddmTemplateItemSelectorCriterion;
 		_httpServletRequest = httpServletRequest;
 		_portletURL = portletURL;
@@ -110,10 +113,17 @@ public class DDMTemplateItemSelectorViewDescriptor
 				getOrderByCol(), getOrderByType()));
 		ddmTemplateSearchContainer.setOrderByType(getOrderByType());
 
+		DDMStructure ddmStructure = _ddmStructureLocalService.getDDMStructure(
+			_ddmTemplateItemSelectorCriterion.getDDMStructureId());
+
 		long[] groupIds =
 			SiteConnectedGroupGroupProviderUtil.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
-					_themeDisplay.getScopeGroupId(), false, true);
+					new long[] {
+						_themeDisplay.getSiteGroupId(),
+						ddmStructure.getGroupId()
+					},
+					false);
 
 		ddmTemplateSearchContainer.setResultsAndTotal(
 			() -> DDMTemplateServiceUtil.search(
@@ -156,6 +166,7 @@ public class DDMTemplateItemSelectorViewDescriptor
 		return _keywords;
 	}
 
+	private final DDMStructureLocalService _ddmStructureLocalService;
 	private final DDMTemplateItemSelectorCriterion
 		_ddmTemplateItemSelectorCriterion;
 	private final HttpServletRequest _httpServletRequest;


### PR DESCRIPTION
1. Derive the allowed groups from the union of the current site and the structure's own group.
2. Anchor on getSiteGroupId() so URL-driven scope changes can't bypass the filter.