### PR TITLE
LPD-93944

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -95,6 +95,7 @@ boolean viewMode = Objects.equals(ParamUtil.getString(PortalUtil.getOriginalServ
 						cssClass="header-back-to lfr-portal-tooltip"
 						href="<%= redirect %>"
 						icon="angle-left"
+						rel="nofollow"
 						title='<%= LanguageUtil.get(request, "back") %>'
 					/>
 				</c:if>


### PR DESCRIPTION
{[LPD-93944)](https://liferay.atlassian.net/browse/LPD-93944)}

Improve the SEO behavior of Asset Publisher pages by ensuring canonical URLs are generated correctly and that navigation links do not create unintended search engine indexing paths.

# How am I fixing it?

Exclude Asset Publisher-specific URL segments from canonical URLs and mark Asset Publisher back button links as non-followable by search engines. Additional tests are included to verify the expected behavior.

# How can you verify that it works?

Run the included automated tests.